### PR TITLE
Don't require `AsyncRead + AsyncWrite` on Protocol itself

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::marker::Unpin;
 
-pub struct Protocol<S: AsyncRead + AsyncWrite> {
+pub struct Protocol<S> {
     io: BufReader<S>,
 }
 


### PR DESCRIPTION
It's only needed in the `impl` blocks, not for the struct itself.
Removing this bounds adds more flexiblity for downstream users and makes generic code easier to write.