### PR TITLE
Only write to the IO object once when creating request

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -28,9 +28,9 @@ where
     pub async fn get<K: AsRef<[u8]>>(&mut self, key: K) -> Result<Vec<u8>, Error> {
         // Send command
         let writer = self.io.get_mut();
-        writer.write_all(b"get ").await?;
-        writer.write_all(key.as_ref()).await?;
-        writer.write_all(b"\r\n").await?;
+        writer
+            .write_all(&[b"get ", key.as_ref(), b"\r\n"].concat())
+            .await?;
         writer.flush().await?;
 
         // Read response header


### PR DESCRIPTION
Hi!

First off, thank you for creating this library 😄 I'm currently using it in conjuction with [bb8-memcached](https://github.com/dqminh/bb8-memcached). I noticed that the bump to `0.6.4` created a performance regression when reading the initial response header in the `get` call. 

I did some profiling and it seems like the reason why due to scheduling with `tokio`. `bb8-memcached` uses `tokio::net::TcpStream` to pass to this library, which looks like it's doing some thread park/un-parking logic more than it used to after the version bump.

I traced it down to the change for calling `memcached` where multiple async writes were being made to the IO buffer. Instead of doing multiple writes, I've changed it to do only one. In my testing through my application, this has removed the performance impact that was happening.

Let me know if you have any concerns! Happy to make more changes if necessary