### PR TITLE
Fix conflicting async io feature compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/memcache-async"
 homepage = "https://github.com/vavrusa/memcache-async"
 
 [dependencies]
+cfg-if = "1.0.1"
 futures = { version = "0.3" }
 tokio = { version = "1.37", features = ["io-util"] }
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,11 +1,22 @@
 //! This is a simplified implementation of [rust-memcache](https://github.com/aisk/rust-memcache)
 //! ported for AsyncRead + AsyncWrite.
 use core::fmt::Display;
-#[cfg(feature = "with-futures")]
-use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
-#[cfg(feature = "with-tokio")]
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use cfg_if::cfg_if;
+
+cfg_if! {
+    // The order here matters. If both features are enabled,
+    // this one will be chosen, avoiding a conflict.
+    if #[cfg(feature = "with-tokio")] {
+        use tokio::io as async_io;
+    } else if #[cfg(feature = "with-futures")] {
+        use futures::io as async_io;
+    } else {
+        compile_error!("An async I/O feature ('with-tokio' or 'with-futures') must be enabled.");
+    }
+}
+
+use async_io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};


### PR DESCRIPTION
Previously, enabling `with-tokio` would also activate the `default` feature (`with-futures`), because Cargo includes default features by design. This would lead to a compilation error due to duplicate definitions from both `use` statements. Example:

```sh
$ cargo build --features with-tokio
error[E0252]: the name `AsyncRead` is defined multiple times
 --> src/ascii.rs:8:34
  |
5 | use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                    --------- previous import of the trait `AsyncRead` here
...
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                  ^^^^^^^^^ `AsyncRead` reimported here
  |
  = note: `AsyncRead` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead as OtherAsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                            +++++++++++++++++

error[E0252]: the name `AsyncReadExt` is defined multiple times
 --> src/ascii.rs:8:45
  |
5 | use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                               ------------ previous import of the trait `AsyncReadExt` here
...
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                             ^^^^^^^^^^^^ `AsyncReadExt` reimported here
  |
  = note: `AsyncReadExt` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt as OtherAsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                          ++++++++++++++++++++

error[E0252]: the name `AsyncWrite` is defined multiple times
 --> src/ascii.rs:8:59
  |
5 | use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                             ---------- previous import of the trait `AsyncWrite` here
...
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                           ^^^^^^^^^^ `AsyncWrite` reimported here
  |
  = note: `AsyncWrite` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite as OtherAsyncWrite, AsyncWriteExt, BufReader};
  |                                                                      ++++++++++++++++++

error[E0252]: the name `AsyncWriteExt` is defined multiple times
 --> src/ascii.rs:8:71
  |
5 | use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                                         ------------- previous import of the trait `AsyncWriteExt` here
...
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                                       ^^^^^^^^^^^^^ `AsyncWriteExt` reimported here
  |
  = note: `AsyncWriteExt` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt as OtherAsyncWriteExt, BufReader};
  |                                                                                     +++++++++++++++++++++

error[E0252]: the name `BufReader` is defined multiple times
 --> src/ascii.rs:8:86
  |
5 | use futures::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                                                        --------- previous import of the type `BufReader` here
...
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                                                                                      ^^^^^^^^^ `BufReader` reimported here
  |
  = note: `BufReader` must be defined only once in the type namespace of this module
help: you can use `as` to change the binding name of the import
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader as OtherBufReader};
  |                                                                                                +++++++++++++++++

warning: unused imports: `AsyncBufReadExt`, `AsyncReadExt`, `AsyncRead`, `AsyncWriteExt`, `AsyncWrite`, and `BufReader`
 --> src/ascii.rs:8:17
  |
8 | use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
  |                 ^^^^^^^^^^^^^^^  ^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0252`.
warning: `memcache-async` (lib) generated 1 warning
error: could not compile `memcache-async` (lib) due to 6 previous errors; 1 warning emitted
```

This commit replaces the separate `#[cfg]` blocks with a single `cfg_if` macro. This creates a prioritized selection for the io backend.